### PR TITLE
Bug fix : input validation error tooltip

### DIFF
--- a/src/components/compound-components/ActionBox.js
+++ b/src/components/compound-components/ActionBox.js
@@ -240,7 +240,7 @@ class ActionBox extends Component {
                                 <div className="currency-input tooltip-container">
                                 {this.showSetMax() && <div className="set-max" onClick={this.setMax}>Set Max</div>}
                                     <input type="text" value={val} onChange={this.onInputChange} placeholder={`Amount in ${coin.symbol}`} ref={e => this.input = e} />
-                                    {inputErrMsg && <Tooltip bottom={true} className={'warning'}>{inputErrMsg}</Tooltip>}
+                                    {inputErrMsg && <Tooltip bottom={true} className={'warning limited-width'}>{inputErrMsg}</Tooltip>}
                                 </div>
                                 <Unlock coin={coin} action={action}/>
                             </Flex>

--- a/src/scss/_utils.scss
+++ b/src/scss/_utils.scss
@@ -22,6 +22,15 @@
   }
 }
 
+.limited-width {
+  width: 100%;
+  margin-right: -115px;
+  min-height: 40px;
+  height: initial;
+  padding: 15px;
+  white-space: initial;
+}
+
 .tickbox {
   width: 37px;
   height: 14px;

--- a/src/scss/_utils.scss
+++ b/src/scss/_utils.scss
@@ -24,7 +24,6 @@
 
 .limited-width {
   width: 100%;
-  margin-right: -115px;
   min-height: 40px;
   height: initial;
   padding: 15px;


### PR DESCRIPTION
# Bug Fix
limiting the width of the input validation error tooltip

![Screen Shot 2021-03-02 at 13 37 48](https://user-images.githubusercontent.com/13344801/109643337-c5c28780-7b5c-11eb-8f13-502b24e59b8e.png)
![Screen Shot 2021-03-02 at 13 36 42](https://user-images.githubusercontent.com/13344801/109643349-c78c4b00-7b5c-11eb-9733-d88b21711441.png)
![Screen Shot 2021-03-02 at 13 36 22](https://user-images.githubusercontent.com/13344801/109643350-c824e180-7b5c-11eb-934d-39bfb98d7228.png)
